### PR TITLE
convert pages format to github markdown

### DIFF
--- a/osquery.md
+++ b/osquery.md
@@ -1,0 +1,363 @@
+<span id="cover.xhtml"></span>
+
+<div class="body" style="white-space:pre-wrap; line-break:strict;">
+
+[<span class="c1 c2"
+dir="ltr">osquery</span>](https://github.com/facebook/osquery) for Mac
+Security
+
+Whitepaper
+
+<span
+style="display:inline-block;float:right;margin-bottom:2.5641%;margin-left:2.5641%;margin-right:18.6705%;margin-top:2.5641%;text-indent:0px;vertical-align:baseline;width:29.411em;">![logo-big.png](images/logo-big.png)</span>
+
+ 
+
+ 
+
+ 
+
+ 
+
+ 
+
+ 
+
+ 
+
+ 
+
+ 
+
+ 
+
+ 
+
+Prepared by Allister Banks. Last updated May, 2016
+
+Background {.s6}
+==========
+
+ 
+
+Facebook started the osquery project after assessing the products
+available to secure their production Linux servers and Mac fleet.
+Nothing on the market allowed them to have adequate performance and deep
+inspection via native APIs, nor could they discover the state of systems
+while subscribing to events at scale (hundreds of thousands of systems).
+This whitepaper details its use specifically on Macs.
+
+ 
+
+[<span class="c3" dir="ltr">Executive Summary</span>](#chapter-1.xhtml)
+
+[<span class="c3" dir="ltr">Explanation of Features and
+Concepts</span>](#chapter-2.xhtml)
+
+[<span class="c3" dir="ltr">Deployment and Vulnerability
+Detection</span>](#chapter-3.xhtml)
+
+[<span class="c3" dir="ltr">Industry Specific
+Compliance</span>](#chapter-4.xhtml)
+
+[<span class="c3" dir="ltr">Conclusion</span>](#chapter-5.xhtml)
+
+ 
+
+</div>
+
+<span id="chapter-1.xhtml"></span>
+
+<div class="body" style="white-space:pre-wrap; line-break:strict;">
+
+<span id="chapter-1.xhtml#chapter-1"></span>
+Executive Summary
+
+The osquery project allows inspection of Macs by enabling administrators
+to run sql-like queries on a running operating system. This allows
+anomaly detection to happen in real time, as logged by its daemon,
+without sacrificing performance. To share their methods and collaborate
+on the code base, the Facebook developers who maintain and continuously
+extend the capabilities of the project develop it in the open on
+GitHub[<span
+class="c4">^1^</span>](#footnotes.xhtml#footnote1){#footnote-ref1}. Code
+review is performed on every check in, and a consistent release process
+ensure rapid improvements do not affect stability. ‘Packs’ allow
+community members to collaborate on common things to detect and report
+on, which facilitates timely flagging of ‘indications of compromise’.
+This relieves the engineering and administration burden of the community
+as a whole, and makes securing systems as per industry standards like
+PCI-DSS and HIPAA a maintainable process.
+
+ 
+
+</div>
+
+<span id="chapter-2.xhtml"></span>
+
+<div class="body" style="white-space:pre-wrap; line-break:strict;">
+
+<span id="chapter-2.xhtml#chapter-2"></span>
+Explanation of Features and Concepts
+
+While the product can also be used on Linux and Windows systems, we will
+only be covering its use on Apple Mac workstations. The osquery toolset
+contains different moving parts that are employed based on how it will
+be used, and are conceptually arranged around its database-like model.
+Perhaps more optimal than tracking down changes during incident
+response, osquery can report on the state of an operating system over
+time. It does not attempt to block functionality or remediate when a OS
+is considered out of compliance. The most fundamental concept of its
+model to understand are the tables.
+
+ 
+
+Tables
+
+ 
+
+Just like a regular database, data returned by osquery is organized into
+tables with rows and columns. The criteria for some tables are
+separately geared toward each OS, and Darwin (the kernel underneath Mac
+OS X) has the majority of ones that ship with osquery.
+Platform-independent criteria can be of use to ensure that e.g. DNS for
+a specific host has not been hijacked, among many other concerns like
+running processes. Mac-specific tables are added over time, and the ones
+currently shipping with the release version are listed here: [<span
+class="c1 c3"
+dir="ltr">https://osquery.io/docs/tables/\#darwin</span>](https://osquery.io/docs/tables/#darwin)
+
+ 
+
+osqueryi
+
+ 
+
+To interactively query the tables once the tools have been installed,
+you can run the osqueryi command in a shell like the Terminal
+application on a Mac. You can ask for things like what tables of data
+can currently be returned on the computer by using the sqlite-style
+syntax for commands.
+
+<span class="c5">\$ osqueryi "SELECT cpu\_brand, physical\_memory FROM
+system\_info;"</span>
+
+<span
+class="c5">+----------------------------------------+-----------------+</span>
+
+<span class="c5">| cpu\_brand | physical\_memory |</span>
+
+<span
+class="c5">+----------------------------------------+-----------------+</span>
+
+<span class="c5">| Intel(R) Core(TM) M-5Y71 CPU @ 1.20GHz | 8589934592
+|</span>
+
+<span
+class="c5">+----------------------------------------+-----------------+</span>
+
+ 
+
+osqueryd
+
+ 
+
+By leveraging a background daemon that will either keep your queries
+running on a schedule or keep tabs on an event stream (for the criteria
+that requires constant monitoring), osqueryd is the recommended model to
+use when deploying at scale. Paired with logging and shipping those logs
+to an aggregation endpoint, it becomes a way to get real-time metrics
+back in the same way critical server systems would be monitored.
+
+ 
+
+Plugins
+
+ 
+
+Using C++ allows osquery to interact with the native API of the
+operating systems it supports. Getting data in to osquery via tables is
+important, and lowering the barrier to entry has been a priority as
+well. In addition to C++, developers looking to contribute can use the
+thrift API to build tables and interact with osquery, which is bundled
+with osquery-python[<span
+class="c4">^2^</span>](#footnotes.xhtml#footnote2){#footnote-ref2}.
+
+ 
+
+</div>
+
+<span id="chapter-3.xhtml"></span>
+
+<div class="body" style="white-space:pre-wrap; line-break:strict;">
+
+<span id="chapter-3.xhtml#chapter-3"></span>
+Deployment and Vulnerability Detection
+
+The plugin framework referred to above can also be used to get logging
+data out of osquery, but to approach this topic we should talk about the
+breadth of what you can do with the tool. Even scheduled checks of the
+presence of issue can only be so instructive. Identifying trends becomes
+important as possibly benign behavior can become compromised or turn
+malicious over time. osquery therefore has a daemon you can configure to
+accept a stream of events.
+
+ 
+
+A common workflow is to take the desired output discovered during an
+osqueryi session and configure osqueryd to subscribe to the state of
+that criteria. This is more commonly paired with a log-shipper so that
+the stream of events can be processed off of the host, and the same
+plugin framework described above can allow integration with different
+systems like Splunk or [<span class="c1 c3"
+dir="ltr">elastic.co</span>](http://elastic.co)’s Elasticsearch.
+
+ 
+
+Packs
+
+ 
+
+Currently the osquery project maintains common interesting criteria to
+check for when scanning or subscribing to events on Macs, grouped into a
+file format called Packs. They are leveraged by osqueryd, and the first
+ones released by Facebook have headings like ‘incident-response’,
+‘it-compliance’, ‘osx-attacks', and ‘vuln-management’, found here:
+[<span class="c1 c3"
+dir="ltr">https://osquery.io/docs/packs/</span>](https://osquery.io/docs/packs/).
+
+ 
+
+Facebook has used their tool to proactively secure their Mac fleet.
+Examples of using osquery for vulnerability detection include the
+‘wirelurker’ exploit discovered last year on Macs, which Facebook
+themselves demonstrated a detection process on their Protect the Graph
+site[<span
+class="c4">^3^</span>](#footnotes.xhtml#footnote3){#footnote-ref3}.
+Another example was an exploit in June 2015 that abused keychain access
+control lists on the Mac, which was also shared on the same site[<span
+class="c4">^4^</span>](#footnotes.xhtml#footnote4){#footnote-ref4}.
+
+ 
+
+</div>
+
+<span id="chapter-4.xhtml"></span>
+
+<div class="body" style="white-space:pre-wrap; line-break:strict;">
+
+<span id="chapter-4.xhtml#chapter-4"></span>
+Industry Specific Compliance
+
+HIPAA
+
+ 
+
+As specified in the Administrative Simplification 164.312(b)[<span
+class="c4">^5^</span>](#footnotes.xhtml#footnote5){#footnote-ref5}, the
+standard to implement software controls that record and examine activity
+on systems which may contain or use electronic protected health
+information plays into osquery’s strengths. Many of the other
+recommended standards are already included in the tables that ship with
+the product, all of which can be employed with minimal performance
+impact.
+
+ 
+
+PCI DSS
+
+ 
+
+For known and not-yet-disclosed vulnerabilities like those exploited by
+adware, malware, trojans, and viruses, osquery can detect indications of
+compromise the moment they begin displaying that behavior on affected
+systems. This is in line with PCI DSS guideline 10.2.7, regarding
+logging the creation and deletion of system-level objects[<span
+class="c4">^6^</span>](#footnotes.xhtml#footnote6){#footnote-ref6}.
+
+ 
+
+NIST 800-53
+
+ 
+
+Working hand-in-hand with configuration management tools that ensure
+compliance like Puppet or Chef, osquery can also detect that the
+enforced firmware or configurations are not modified over time.
+Cryptographically proving the signature on objects is made possible
+through its file integrity monitoring, which uses the approved SHA-256
+NIST algorithm, as dictated by security control SI-7(6)[<span
+class="c4">^7^</span>](#footnotes.xhtml#footnote7){#footnote-ref7}.
+
+ 
+
+</div>
+
+<span id="chapter-5.xhtml"></span>
+
+<div class="body" style="white-space:pre-wrap; line-break:strict;">
+
+<span id="chapter-5.xhtml#chapter-5"></span>
+Conclusion
+
+With its unique tailoring to the Mac platform, focus on performance, and
+responsiveness from a community of developers employed to maintain it,
+osquery is becoming an essential monitoring tool for large
+installations. It is the manifestation of the idea that no vendor can
+detect all possible vulnerabilities, and efficiently profiling the
+effects of a compromise helps you remediate with full historical
+accuracy.
+
+</div>
+
+<span id="footnotes.xhtml"></span>
+
+<div class="body">
+
+[](){#footnote1}
+[<span class="c4">^1^</span>](#chapter-1.xhtml#footnote-ref1) [<span
+class="c1 c3"
+dir="ltr">https://github.com/facebook/osquery</span>](https://github.com/facebook/osquery)
+
+\
+[](){#footnote2}
+[<span class="c4">^2^</span>](#chapter-2.xhtml#footnote-ref2) [<span
+class="c1 c3"
+dir="ltr">https://github.com/osquery/osquery-python</span>](https://github.com/osquery/osquery-python)
+
+\
+[](){#footnote3}
+[<span class="c4">^3^</span>](#chapter-3.xhtml#footnote-ref3)[<span
+class="c1 c3"
+dir="ltr">https://www.facebook.com/notes/protect-the-graph/anomaly-detection-using-osquery/1532788613627951</span>](https://www.facebook.com/notes/protect-the-graph/anomaly-detection-using-osquery/1532788613627951)
+
+\
+[](){#footnote4}
+[<span class="c4">^4^</span>](#chapter-3.xhtml#footnote-ref4)[<span
+class="c1 c3"
+dir="ltr">https://www.facebook.com/notes/protect-the-graph/detecting-unauthorized-cross-app-resource-access-on-os-x/1619875274919284</span>](https://www.facebook.com/notes/protect-the-graph/detecting-unauthorized-cross-app-resource-access-on-os-x/1619875274919284)
+
+\
+[](){#footnote5}
+[<span class="c4">^5^</span>](#chapter-4.xhtml#footnote-ref5) [<span
+class="c1 c3"
+dir="ltr">http://www.hhs.gov/ocr/privacy/hipaa/administrative/combined/hipaa-simplification-201303.pdf</span>](http://www.hhs.gov/ocr/privacy/hipaa/administrative/combined/hipaa-simplification-201303.pdf)
+pg. 67
+
+\
+[](){#footnote6}
+[<span class="c4">^6^</span>](#chapter-4.xhtml#footnote-ref6) [<span
+class="c1 c3"
+dir="ltr">https://www.pcisecuritystandards.org/documents/PCI\_DSS\_v3-1.pdf</span>](https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-1.pdf)
+pg. 86
+
+\
+[](){#footnote7}
+[<span class="c4">^7^</span>](#chapter-4.xhtml#footnote-ref7) [<span
+class="c1 c3"
+dir="ltr">http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf</span>](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf)
+pg. 40
+
+\
+
+</div>

--- a/osquery.md
+++ b/osquery.md
@@ -1,15 +1,10 @@
 <span id="cover.xhtml"></span>
 
-<div class="body" style="white-space:pre-wrap; line-break:strict;">
-
-[<span class="c1 c2"
-dir="ltr">osquery</span>](https://github.com/facebook/osquery) for Mac
-Security
+[<span class="c1 c2" dir="ltr">osquery</span>](https://github.com/facebook/osquery) for Mac Security
 
 Whitepaper
 
-<span
-style="display:inline-block;float:right;margin-bottom:2.5641%;margin-left:2.5641%;margin-right:18.6705%;margin-top:2.5641%;text-indent:0px;vertical-align:baseline;width:29.411em;">![logo-big.png](images/logo-big.png)</span>
+<span style="display:inline-block;float:right;margin-bottom:2.5641%;margin-left:2.5641%;margin-right:18.6705%;margin-top:2.5641%;text-indent:0px;vertical-align:baseline;width:29.411em;">![logo-big.png](images/logo-big.png)</span>
 
  
 
@@ -35,80 +30,42 @@ style="display:inline-block;float:right;margin-bottom:2.5641%;margin-left:2.5641
 
 Prepared by Allister Banks. Last updated May, 2016
 
-Background {.s6}
+Background
 ==========
 
  
 
-Facebook started the osquery project after assessing the products
-available to secure their production Linux servers and Mac fleet.
-Nothing on the market allowed them to have adequate performance and deep
-inspection via native APIs, nor could they discover the state of systems
-while subscribing to events at scale (hundreds of thousands of systems).
-This whitepaper details its use specifically on Macs.
+Facebook started the osquery project after assessing the products available to secure their production Linux servers and Mac fleet. Nothing on the market allowed them to have adequate performance and deep inspection via native APIs, nor could they discover the state of systems while subscribing to events at scale (hundreds of thousands of systems). This whitepaper details its use specifically on Macs.
 
  
 
 [<span class="c3" dir="ltr">Executive Summary</span>](#chapter-1.xhtml)
 
-[<span class="c3" dir="ltr">Explanation of Features and
-Concepts</span>](#chapter-2.xhtml)
+[<span class="c3" dir="ltr">Explanation of Features and Concepts</span>](#chapter-2.xhtml)
 
-[<span class="c3" dir="ltr">Deployment and Vulnerability
-Detection</span>](#chapter-3.xhtml)
+[<span class="c3" dir="ltr">Deployment and Vulnerability Detection</span>](#chapter-3.xhtml)
 
-[<span class="c3" dir="ltr">Industry Specific
-Compliance</span>](#chapter-4.xhtml)
+[<span class="c3" dir="ltr">Industry Specific Compliance</span>](#chapter-4.xhtml)
 
 [<span class="c3" dir="ltr">Conclusion</span>](#chapter-5.xhtml)
 
  
 
-</div>
-
 <span id="chapter-1.xhtml"></span>
-
-<div class="body" style="white-space:pre-wrap; line-break:strict;">
 
 <span id="chapter-1.xhtml#chapter-1"></span>
 Executive Summary
 
-The osquery project allows inspection of Macs by enabling administrators
-to run sql-like queries on a running operating system. This allows
-anomaly detection to happen in real time, as logged by its daemon,
-without sacrificing performance. To share their methods and collaborate
-on the code base, the Facebook developers who maintain and continuously
-extend the capabilities of the project develop it in the open on
-GitHub[<span
-class="c4">^1^</span>](#footnotes.xhtml#footnote1){#footnote-ref1}. Code
-review is performed on every check in, and a consistent release process
-ensure rapid improvements do not affect stability. ‘Packs’ allow
-community members to collaborate on common things to detect and report
-on, which facilitates timely flagging of ‘indications of compromise’.
-This relieves the engineering and administration burden of the community
-as a whole, and makes securing systems as per industry standards like
-PCI-DSS and HIPAA a maintainable process.
+The osquery project allows inspection of Macs by enabling administrators to run sql-like queries on a running operating system. This allows anomaly detection to happen in real time, as logged by its daemon, without sacrificing performance. To share their methods and collaborate on the code base, the Facebook developers who maintain and continuously extend the capabilities of the project develop it in the open on GitHub<a href="#footnotes.xhtml#footnote1" id="footnote-ref1"><span class="c4"><sup>1</sup></span></a>. Code review is performed on every check in, and a consistent release process ensure rapid improvements do not affect stability. ‘Packs’ allow community members to collaborate on common things to detect and report on, which facilitates timely flagging of ‘indications of compromise’. This relieves the engineering and administration burden of the community as a whole, and makes securing systems as per industry standards like PCI-DSS and HIPAA a maintainable process.
 
  
 
-</div>
-
 <span id="chapter-2.xhtml"></span>
-
-<div class="body" style="white-space:pre-wrap; line-break:strict;">
 
 <span id="chapter-2.xhtml#chapter-2"></span>
 Explanation of Features and Concepts
 
-While the product can also be used on Linux and Windows systems, we will
-only be covering its use on Apple Mac workstations. The osquery toolset
-contains different moving parts that are employed based on how it will
-be used, and are conceptually arranged around its database-like model.
-Perhaps more optimal than tracking down changes during incident
-response, osquery can report on the state of an operating system over
-time. It does not attempt to block functionality or remediate when a OS
-is considered out of compliance. The most fundamental concept of its
-model to understand are the tables.
+While the product can also be used on Linux and Windows systems, we will only be covering its use on Apple Mac workstations. The osquery toolset contains different moving parts that are employed based on how it will be used, and are conceptually arranged around its database-like model. Perhaps more optimal than tracking down changes during incident response, osquery can report on the state of an operating system over time. It does not attempt to block functionality or remediate when a OS is considered out of compliance. The most fundamental concept of its model to understand are the tables.
 
  
 
@@ -116,16 +73,7 @@ Tables
 
  
 
-Just like a regular database, data returned by osquery is organized into
-tables with rows and columns. The criteria for some tables are
-separately geared toward each OS, and Darwin (the kernel underneath Mac
-OS X) has the majority of ones that ship with osquery.
-Platform-independent criteria can be of use to ensure that e.g. DNS for
-a specific host has not been hijacked, among many other concerns like
-running processes. Mac-specific tables are added over time, and the ones
-currently shipping with the release version are listed here: [<span
-class="c1 c3"
-dir="ltr">https://osquery.io/docs/tables/\#darwin</span>](https://osquery.io/docs/tables/#darwin)
+Just like a regular database, data returned by osquery is organized into tables with rows and columns. The criteria for some tables are separately geared toward each OS, and Darwin (the kernel underneath Mac OS X) has the majority of ones that ship with osquery. Platform-independent criteria can be of use to ensure that e.g. DNS for a specific host has not been hijacked, among many other concerns like running processes. Mac-specific tables are added over time, and the ones currently shipping with the release version are listed here: [<span class="c1 c3" dir="ltr">https://osquery.io/docs/tables/\#darwin</span>](https://osquery.io/docs/tables/#darwin)
 
  
 
@@ -133,28 +81,19 @@ osqueryi
 
  
 
-To interactively query the tables once the tools have been installed,
-you can run the osqueryi command in a shell like the Terminal
-application on a Mac. You can ask for things like what tables of data
-can currently be returned on the computer by using the sqlite-style
-syntax for commands.
+To interactively query the tables once the tools have been installed, you can run the osqueryi command in a shell like the Terminal application on a Mac. You can ask for things like what tables of data can currently be returned on the computer by using the sqlite-style syntax for commands.
 
-<span class="c5">\$ osqueryi "SELECT cpu\_brand, physical\_memory FROM
-system\_info;"</span>
+<span class="c5">$ osqueryi "SELECT cpu\_brand, physical\_memory FROM system\_info;"</span>
 
-<span
-class="c5">+----------------------------------------+-----------------+</span>
+<span class="c5">+----------------------------------------+-----------------+</span>
 
 <span class="c5">| cpu\_brand | physical\_memory |</span>
 
-<span
-class="c5">+----------------------------------------+-----------------+</span>
+<span class="c5">+----------------------------------------+-----------------+</span>
 
-<span class="c5">| Intel(R) Core(TM) M-5Y71 CPU @ 1.20GHz | 8589934592
-|</span>
+<span class="c5">| Intel(R) Core(TM) M-5Y71 CPU @ 1.20GHz | 8589934592 |</span>
 
-<span
-class="c5">+----------------------------------------+-----------------+</span>
+<span class="c5">+----------------------------------------+-----------------+</span>
 
  
 
@@ -162,12 +101,7 @@ osqueryd
 
  
 
-By leveraging a background daemon that will either keep your queries
-running on a schedule or keep tabs on an event stream (for the criteria
-that requires constant monitoring), osqueryd is the recommended model to
-use when deploying at scale. Paired with logging and shipping those logs
-to an aggregation endpoint, it becomes a way to get real-time metrics
-back in the same way critical server systems would be monitored.
+By leveraging a background daemon that will either keep your queries running on a schedule or keep tabs on an event stream (for the criteria that requires constant monitoring), osqueryd is the recommended model to use when deploying at scale. Paired with logging and shipping those logs to an aggregation endpoint, it becomes a way to get real-time metrics back in the same way critical server systems would be monitored.
 
  
 
@@ -175,42 +109,20 @@ Plugins
 
  
 
-Using C++ allows osquery to interact with the native API of the
-operating systems it supports. Getting data in to osquery via tables is
-important, and lowering the barrier to entry has been a priority as
-well. In addition to C++, developers looking to contribute can use the
-thrift API to build tables and interact with osquery, which is bundled
-with osquery-python[<span
-class="c4">^2^</span>](#footnotes.xhtml#footnote2){#footnote-ref2}.
+Using C++ allows osquery to interact with the native API of the operating systems it supports. Getting data in to osquery via tables is important, and lowering the barrier to entry has been a priority as well. In addition to C++, developers looking to contribute can use the thrift API to build tables and interact with osquery, which is bundled with osquery-python<a href="#footnotes.xhtml#footnote2" id="footnote-ref2"><span class="c4"><sup>2</sup></span></a>.
 
  
 
-</div>
-
 <span id="chapter-3.xhtml"></span>
-
-<div class="body" style="white-space:pre-wrap; line-break:strict;">
 
 <span id="chapter-3.xhtml#chapter-3"></span>
 Deployment and Vulnerability Detection
 
-The plugin framework referred to above can also be used to get logging
-data out of osquery, but to approach this topic we should talk about the
-breadth of what you can do with the tool. Even scheduled checks of the
-presence of issue can only be so instructive. Identifying trends becomes
-important as possibly benign behavior can become compromised or turn
-malicious over time. osquery therefore has a daemon you can configure to
-accept a stream of events.
+The plugin framework referred to above can also be used to get logging data out of osquery, but to approach this topic we should talk about the breadth of what you can do with the tool. Even scheduled checks of the presence of issue can only be so instructive. Identifying trends becomes important as possibly benign behavior can become compromised or turn malicious over time. osquery therefore has a daemon you can configure to accept a stream of events.
 
  
 
-A common workflow is to take the desired output discovered during an
-osqueryi session and configure osqueryd to subscribe to the state of
-that criteria. This is more commonly paired with a log-shipper so that
-the stream of events can be processed off of the host, and the same
-plugin framework described above can allow integration with different
-systems like Splunk or [<span class="c1 c3"
-dir="ltr">elastic.co</span>](http://elastic.co)’s Elasticsearch.
+A common workflow is to take the desired output discovered during an osqueryi session and configure osqueryd to subscribe to the state of that criteria. This is more commonly paired with a log-shipper so that the stream of events can be processed off of the host, and the same plugin framework described above can allow integration with different systems like Splunk or [<span class="c1 c3" dir="ltr">elastic.co</span>](http://elastic.co)’s Elasticsearch.
 
  
 
@@ -218,33 +130,15 @@ Packs
 
  
 
-Currently the osquery project maintains common interesting criteria to
-check for when scanning or subscribing to events on Macs, grouped into a
-file format called Packs. They are leveraged by osqueryd, and the first
-ones released by Facebook have headings like ‘incident-response’,
-‘it-compliance’, ‘osx-attacks', and ‘vuln-management’, found here:
-[<span class="c1 c3"
-dir="ltr">https://osquery.io/docs/packs/</span>](https://osquery.io/docs/packs/).
+Currently the osquery project maintains common interesting criteria to check for when scanning or subscribing to events on Macs, grouped into a file format called Packs. They are leveraged by osqueryd, and the first ones released by Facebook have headings like ‘incident-response’, ‘it-compliance’, ‘osx-attacks', and ‘vuln-management’, found here: [<span class="c1 c3" dir="ltr">https://osquery.io/docs/packs/</span>](https://osquery.io/docs/packs/).
 
  
 
-Facebook has used their tool to proactively secure their Mac fleet.
-Examples of using osquery for vulnerability detection include the
-‘wirelurker’ exploit discovered last year on Macs, which Facebook
-themselves demonstrated a detection process on their Protect the Graph
-site[<span
-class="c4">^3^</span>](#footnotes.xhtml#footnote3){#footnote-ref3}.
-Another example was an exploit in June 2015 that abused keychain access
-control lists on the Mac, which was also shared on the same site[<span
-class="c4">^4^</span>](#footnotes.xhtml#footnote4){#footnote-ref4}.
+Facebook has used their tool to proactively secure their Mac fleet. Examples of using osquery for vulnerability detection include the ‘wirelurker’ exploit discovered last year on Macs, which Facebook themselves demonstrated a detection process on their Protect the Graph site<a href="#footnotes.xhtml#footnote3" id="footnote-ref3"><span class="c4"><sup>3</sup></span></a>. Another example was an exploit in June 2015 that abused keychain access control lists on the Mac, which was also shared on the same site<a href="#footnotes.xhtml#footnote4" id="footnote-ref4"><span class="c4"><sup>4</sup></span></a>.
 
  
-
-</div>
 
 <span id="chapter-4.xhtml"></span>
-
-<div class="body" style="white-space:pre-wrap; line-break:strict;">
 
 <span id="chapter-4.xhtml#chapter-4"></span>
 Industry Specific Compliance
@@ -253,14 +147,7 @@ HIPAA
 
  
 
-As specified in the Administrative Simplification 164.312(b)[<span
-class="c4">^5^</span>](#footnotes.xhtml#footnote5){#footnote-ref5}, the
-standard to implement software controls that record and examine activity
-on systems which may contain or use electronic protected health
-information plays into osquery’s strengths. Many of the other
-recommended standards are already included in the tables that ship with
-the product, all of which can be employed with minimal performance
-impact.
+As specified in the Administrative Simplification 164.312(b)<a href="#footnotes.xhtml#footnote5" id="footnote-ref5"><span class="c4"><sup>5</sup></span></a>, the standard to implement software controls that record and examine activity on systems which may contain or use electronic protected health information plays into osquery’s strengths. Many of the other recommended standards are already included in the tables that ship with the product, all of which can be employed with minimal performance impact.
 
  
 
@@ -268,12 +155,7 @@ PCI DSS
 
  
 
-For known and not-yet-disclosed vulnerabilities like those exploited by
-adware, malware, trojans, and viruses, osquery can detect indications of
-compromise the moment they begin displaying that behavior on affected
-systems. This is in line with PCI DSS guideline 10.2.7, regarding
-logging the creation and deletion of system-level objects[<span
-class="c4">^6^</span>](#footnotes.xhtml#footnote6){#footnote-ref6}.
+For known and not-yet-disclosed vulnerabilities like those exploited by adware, malware, trojans, and viruses, osquery can detect indications of compromise the moment they begin displaying that behavior on affected systems. This is in line with PCI DSS guideline 10.2.7, regarding logging the creation and deletion of system-level objects<a href="#footnotes.xhtml#footnote6" id="footnote-ref6"><span class="c4"><sup>6</sup></span></a>.
 
  
 
@@ -281,83 +163,38 @@ NIST 800-53
 
  
 
-Working hand-in-hand with configuration management tools that ensure
-compliance like Puppet or Chef, osquery can also detect that the
-enforced firmware or configurations are not modified over time.
-Cryptographically proving the signature on objects is made possible
-through its file integrity monitoring, which uses the approved SHA-256
-NIST algorithm, as dictated by security control SI-7(6)[<span
-class="c4">^7^</span>](#footnotes.xhtml#footnote7){#footnote-ref7}.
+Working hand-in-hand with configuration management tools that ensure compliance like Puppet or Chef, osquery can also detect that the enforced firmware or configurations are not modified over time. Cryptographically proving the signature on objects is made possible through its file integrity monitoring, which uses the approved SHA-256 NIST algorithm, as dictated by security control SI-7(6)<a href="#footnotes.xhtml#footnote7" id="footnote-ref7"><span class="c4"><sup>7</sup></span></a>.
 
  
 
-</div>
-
 <span id="chapter-5.xhtml"></span>
-
-<div class="body" style="white-space:pre-wrap; line-break:strict;">
 
 <span id="chapter-5.xhtml#chapter-5"></span>
 Conclusion
 
-With its unique tailoring to the Mac platform, focus on performance, and
-responsiveness from a community of developers employed to maintain it,
-osquery is becoming an essential monitoring tool for large
-installations. It is the manifestation of the idea that no vendor can
-detect all possible vulnerabilities, and efficiently profiling the
-effects of a compromise helps you remediate with full historical
-accuracy.
-
-</div>
+With its unique tailoring to the Mac platform, focus on performance, and responsiveness from a community of developers employed to maintain it, osquery is becoming an essential monitoring tool for large installations. It is the manifestation of the idea that no vendor can detect all possible vulnerabilities, and efficiently profiling the effects of a compromise helps you remediate with full historical accuracy.
 
 <span id="footnotes.xhtml"></span>
 
-<div class="body">
+<a href="" id="footnote1"></a>
+[<span class="c4"><sup>1</sup></span>](#chapter-1.xhtml#footnote-ref1) [<span class="c1 c3" dir="ltr">https://github.com/facebook/osquery</span>](https://github.com/facebook/osquery)
 
-[](){#footnote1}
-[<span class="c4">^1^</span>](#chapter-1.xhtml#footnote-ref1) [<span
-class="c1 c3"
-dir="ltr">https://github.com/facebook/osquery</span>](https://github.com/facebook/osquery)
+<a href="" id="footnote2"></a>
+[<span class="c4"><sup>2</sup></span>](#chapter-2.xhtml#footnote-ref2) [<span class="c1 c3" dir="ltr">https://github.com/osquery/osquery-python</span>](https://github.com/osquery/osquery-python)
 
-\
-[](){#footnote2}
-[<span class="c4">^2^</span>](#chapter-2.xhtml#footnote-ref2) [<span
-class="c1 c3"
-dir="ltr">https://github.com/osquery/osquery-python</span>](https://github.com/osquery/osquery-python)
+<a href="" id="footnote3"></a>
+[<span class="c4"><sup>3</sup></span>](#chapter-3.xhtml#footnote-ref3)[<span class="c1 c3" dir="ltr">https://www.facebook.com/notes/protect-the-graph/anomaly-detection-using-osquery/1532788613627951</span>](https://www.facebook.com/notes/protect-the-graph/anomaly-detection-using-osquery/1532788613627951)
 
-\
-[](){#footnote3}
-[<span class="c4">^3^</span>](#chapter-3.xhtml#footnote-ref3)[<span
-class="c1 c3"
-dir="ltr">https://www.facebook.com/notes/protect-the-graph/anomaly-detection-using-osquery/1532788613627951</span>](https://www.facebook.com/notes/protect-the-graph/anomaly-detection-using-osquery/1532788613627951)
+<a href="" id="footnote4"></a>
+[<span class="c4"><sup>4</sup></span>](#chapter-3.xhtml#footnote-ref4)[<span class="c1 c3" dir="ltr">https://www.facebook.com/notes/protect-the-graph/detecting-unauthorized-cross-app-resource-access-on-os-x/1619875274919284</span>](https://www.facebook.com/notes/protect-the-graph/detecting-unauthorized-cross-app-resource-access-on-os-x/1619875274919284)
 
-\
-[](){#footnote4}
-[<span class="c4">^4^</span>](#chapter-3.xhtml#footnote-ref4)[<span
-class="c1 c3"
-dir="ltr">https://www.facebook.com/notes/protect-the-graph/detecting-unauthorized-cross-app-resource-access-on-os-x/1619875274919284</span>](https://www.facebook.com/notes/protect-the-graph/detecting-unauthorized-cross-app-resource-access-on-os-x/1619875274919284)
+<a href="" id="footnote5"></a>
+[<span class="c4"><sup>5</sup></span>](#chapter-4.xhtml#footnote-ref5) [<span class="c1 c3" dir="ltr">http://www.hhs.gov/ocr/privacy/hipaa/administrative/combined/hipaa-simplification-201303.pdf</span>](http://www.hhs.gov/ocr/privacy/hipaa/administrative/combined/hipaa-simplification-201303.pdf) pg. 67
 
-\
-[](){#footnote5}
-[<span class="c4">^5^</span>](#chapter-4.xhtml#footnote-ref5) [<span
-class="c1 c3"
-dir="ltr">http://www.hhs.gov/ocr/privacy/hipaa/administrative/combined/hipaa-simplification-201303.pdf</span>](http://www.hhs.gov/ocr/privacy/hipaa/administrative/combined/hipaa-simplification-201303.pdf)
-pg. 67
+<a href="" id="footnote6"></a>
+[<span class="c4"><sup>6</sup></span>](#chapter-4.xhtml#footnote-ref6) [<span class="c1 c3" dir="ltr">https://www.pcisecuritystandards.org/documents/PCI\_DSS\_v3-1.pdf</span>](https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-1.pdf) pg. 86
 
-\
-[](){#footnote6}
-[<span class="c4">^6^</span>](#chapter-4.xhtml#footnote-ref6) [<span
-class="c1 c3"
-dir="ltr">https://www.pcisecuritystandards.org/documents/PCI\_DSS\_v3-1.pdf</span>](https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-1.pdf)
-pg. 86
+<a href="" id="footnote7"></a>
+[<span class="c4"><sup>7</sup></span>](#chapter-4.xhtml#footnote-ref7) [<span class="c1 c3" dir="ltr">http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf</span>](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf) pg. 40
 
-\
-[](){#footnote7}
-[<span class="c4">^7^</span>](#chapter-4.xhtml#footnote-ref7) [<span
-class="c1 c3"
-dir="ltr">http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf</span>](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf)
-pg. 40
 
-\
-
-</div>


### PR DESCRIPTION
This is an automated conversion from Pages to github flavored markdown. 

Steps:
1. In pages, export as epub.
2. `pandoc -f epub -t markdown_github -o osquery.md osquery.epub`

This document can be cleaned up/edited/contributed to from here. 
